### PR TITLE
add option to start all services to resetserviced

### DIFF
--- a/zendev/resetserviced.sh
+++ b/zendev/resetserviced.sh
@@ -29,7 +29,11 @@ deploy () {
     ${SERVICED} add-host $IP:4979 default
     TEMPLATE_ID=$(${SERVICED} add-template ${EUROPA}/build/services/Zenoss)
     ${SERVICED} deploy-template ${TEMPLATE_ID} default zenoss
+    if [ "${BASH_ARGV[0]}" == "startall" ]; then
+        ${SERVICED} start-service $(serviced services | grep Zenoss | head -n1 | awk {'print $2'})
+    fi
 }
+
 deploy &
 ${SERVICED} -master -agent ${RESETSERVICED_ARGS}
 

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -100,6 +100,8 @@ def resetserviced(args):
                 cmd.insert(0, key + "=" + value)
         cmd.insert(0, "GOPATH=" + os.environ["GOPATH"])
         cmd.insert(0, "sudo")
+    if args.startall:
+        cmd.append('startall')
     subprocess.call(cmd)
 
 
@@ -445,6 +447,8 @@ def parse_args():
     serviced_parser = subparsers.add_parser('resetserviced')
     serviced_parser.add_argument('--root', action='store_true',
         help="run resetserviced as root")
+    serviced_parser.add_argument('--startall', action='store_true',
+        help="start all services")
     serviced_parser.set_defaults(functor=resetserviced)
 
     update_parser = subparsers.add_parser('selfupdate')


### PR DESCRIPTION
zendev resetserviced --startall 

Starts the root Zenoss service, and so all its children.
