### PR TITLE
removed serviced auto-assign-ips ZENOSS_ROOT_SERVICE

### DIFF
--- a/zendev/resetserviced.sh
+++ b/zendev/resetserviced.sh
@@ -31,8 +31,6 @@ deploy () {
     ${SERVICED} deploy-template ${TEMPLATE_ID} default zenoss
     sleep 5
     ZENOSS_ROOT_SERVICE=$(serviced services | awk '/Zenoss/ {print $2; exit}')
-    echo "$(date +'%Y-%m-%d %H:%M:%S'): performing: ${SERVICED} auto-assign-ips ${ZENOSS_ROOT_SERVICE}"
-    ${SERVICED} auto-assign-ips ${ZENOSS_ROOT_SERVICE}
     if [ "${BASH_ARGV[0]}" == "startall" ]; then
         echo "$(date +'%Y-%m-%d %H:%M:%S'): performing: ${SERVICED} start-service ${ZENOSS_ROOT_SERVICE}"
         ${SERVICED} start-service ${ZENOSS_ROOT_SERVICE}


### PR DESCRIPTION
due to auto-assign-ips being done automatically now with deploy-template
  https://github.com/zenoss/serviced/pull/239
