### PR TITLE
Make hostid different on each box

### DIFF
--- a/zendev/cluster.py
+++ b/zendev/cluster.py
@@ -101,11 +101,17 @@ class VagrantClusterManager(object):
             box_name=BOXES.get(purpose),
             shared_folders=shared,
             provision_script="""
+hid=$(%s | cut -c2-10)
+a=${hid:6:2}
+b=${hid:4:2}
+c=${hid:2:2}
+d=${hid:0:2}
+echo -ne \\\\\\\\x$a\\\\\\\\x$b\\\\\\\\x$c\\\\\\\\x$d > /etc/hostid
 chown zenoss:zenoss /home/zenoss/%s
 su - zenoss -c "cd /home/zenoss && zendev init %s"
 echo "source $(zendev bootstrap)" >> /home/zenoss/.bashrc
 echo "zendev use %s" >> /home/zenoss/.bashrc
-""" % (self.env.name, self.env.name, self.env.name)))
+""" % ("date +%s", self.env.name, self.env.name, self.env.name)))
 
     def boot(self, name):
         cluster = self._get_cluster(name)


### PR DESCRIPTION
By default hostid is generated from the eth0 ip address, which is always 10.0.2.15 on a vagrant box, this fix/hack writes stuff to /etc/hostid to make hostid unique per box.
