### PR TITLE
Add ability to cdz to unmanaged source directories inside our srcroot

### DIFF
--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -307,8 +307,14 @@ def cd(args):
             return
         repos = check_env().repos(repofilter([args.repo]))
         if not repos:
-            error("No repo matching %s found" % args.repo)
-            sys.exit(1)
+            # try to fall back to a directory in our srcroot
+            nonRepoPath = env.srcroot.join(args.repo).strpath
+            if os.path.isdir(nonRepoPath):
+                env.bash('cd "%s"' % nonRepoPath)
+                return
+            else:
+                error("No repo matching %s found" % args.repo)
+                sys.exit(1)
         for repo in repos:
             if repo.path.strpath.endswith(args.repo.strip()):
                 env.bash('cd "%s"' % repo.path.strpath)


### PR DESCRIPTION
This enables some non-git use cases for the cdz command.

Like:

```
~$ zendev use 4x
~/src/4x$ cdz core/inst
~/src/4x/src/core/inst$ svn info
Path: .
URL: http://dev.zenoss.com/svnint/branches/core/zenoss_ucsx-4.2.6/inst
Repository Root: http://dev.zenoss.com/svnint
Repository UUID: f5df01ce-0320-0410-9ed9-ddcd13c732cc
Revision: 81789
Node Kind: directory
Schedule: normal
Last Changed Author: obrazhnik
Last Changed Rev: 81551
Last Changed Date: 2014-04-28 01:42:42 -0500 (Mon, 28 Apr 2014)
~/src/4x/src/core/inst$
```
