### PR TITLE
remove nlimit nofile 65536 65536 since higher limits are defaulted on do...

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,7 +69,6 @@ good. Now modify the Docker upstart script to handle resolution of local DNS:
 .. code-block:: bash
 
     cat  <<\EOF | sudo sed -f /dev/fd/0 -i /etc/init/docker.conf
-        s/respawn/\0\nlimit nofile 65536 65536\n/
         s/DOCKER_OPTS=.*$/\0\n\tDOCKER_OPTS="$DOCKER_OPTS -dns=10.87.113.13 -dns=10.88.102.13 -dns=10.175.211.10"/
     EOF
 


### PR DESCRIPTION
...cker 0.11

default for docker 0.11.1 in /etc/init/docker.conf:

```
limit nofile 524288 1048576
limit nproc 524288 1048576
```
