### PR TITLE
update zendev to call serviced template deploy with manualassignips

### DIFF
--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -120,7 +120,7 @@ def serviced(args):
             serviced.add_host()
             tplid = serviced.add_template()
             if args.no_auto_assign_ips:
-                serviced.deploy(template=tplid, noAutoAssignIpFlag="--manual")
+                serviced.deploy(template=tplid, noAutoAssignIpFlag="--manual-assign-ips")
             else:
                 serviced.deploy(tplid)
         if args.startall:


### PR DESCRIPTION
Previously:
Incorrect Usage.

NAME:
   deploy - Deploys a template's services to a pool

USAGE:
   command deploy [command options] [arguments...]

DESCRIPTION:
   serviced template deploy TEMPLATEID POOLID DEPLOYMENTID

OPTIONS:
   --manual-assign-ips  Manually assign IP addresses

After my change, I started serviced and then ran this:
serviced service assign-ip 1kjddgg0a06p420kst6vhytcd 172.17.42.1

Resulting logs:
I0528 17:14:32.687272 18024 service.go:481] Manual IP Address Assignment
I0528 17:14:32.687332 18024 service.go:513] Attempting to set IP address(es) to 172.17.42.1
I0528 17:14:32.766920 18024 addressassignment.go:223] Service: 7sm2izge1rz0bvoqitqq262d8 endpoint: zentrap needs an address assignment
I0528 17:14:32.766995 18024 service.go:548] Creating AddressAssignment for Endpoint: zentrap
I0528 17:14:32.791915 18024 service.go:556] Created AddressAssignment:  for Endpoint: zentrap
I0528 17:14:32.817890 18024 addressassignment.go:223] Service: c8mxv9wja5oppg14xw6elo98v endpoint: syslog needs an address assignment
I0528 17:14:32.817935 18024 service.go:548] Creating AddressAssignment for Endpoint: syslog
I0528 17:14:32.832404 18024 service.go:556] Created AddressAssignment:  for Endpoint: syslog
I0528 17:14:32.937217 18024 service.go:568] All services requiring an explicit IP address (at this moment) from service: 1kjddgg0a06p420kst6vhytcd and down ... have been assigned: 172.17.42.1
