### PR TITLE
Show un-synced repos in zendev status

### DIFF
--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -349,15 +349,21 @@ class ZenDevEnvironment(object):
     def status(self, filter_=None):
         table = []
         for repo in self.repos(filter_):
-            staged, unstaged, untracked = repo.changes
-            color = 'green' if staged else 'blue' if unstaged else None
-            table.append([colored(x, color) for x in [
-                repo.name,
-                repo.branch,
-                '*' if staged else '',
-                '*' if unstaged else '',
-                '*' if untracked else ''
-            ]])
+            if repo.path.check():
+                staged, unstaged, untracked = repo.changes
+                color = 'green' if staged else 'blue' if unstaged else None
+                table.append([colored(x, color) for x in [
+                    repo.name,
+                    repo.branch,
+                    '*' if staged else '',
+                    '*' if unstaged else '',
+                    '*' if untracked else ''
+                ]])
+            else:
+                table.append([colored(x, 'red') for x in [
+                    repo.name,
+                    'not synced'
+                ]])
         print tabulate(table, headers=STATUS_HEADERS)
 
     def feature_filter(self, name, filter_):

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -365,7 +365,7 @@ def status(args):
     elif args.all:
         filter_ = None
     else:
-        filter_ = lambda r:any(r.changes)
+        filter_ = lambda r: not r.path.check() or any(r.changes)
     check_env().status(filter_)
 
 


### PR DESCRIPTION
```
$ zendev add build/manifests/core.json 
$ zendev status
Path                                        Branch
------------------------------------------  ----------
core                                        not synced
metric-service                              not synced
zproxy                                      not synced
zep                                         not synced
metric-consumer                             not synced
zauth-service                               not synced
golang/src/github.com/zenoss/metricshipper  not synced
```
