### PR TITLE
added: zendev devshell

### DIFF
--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -440,6 +440,10 @@ def attach(args):
     subprocess.call("serviced service attach '%s'; stty sane" % args.specifier,
                     shell=True)
 
+def devshell(args):
+    env = check_env()
+    cmd = "docker run -v %s/src:/mnt/src -v %s:/opt/zenoss -i -t zendev/devimg bash" % (env.root.strpath, env.root.join("zenhome").strpath)
+    subprocess.call(cmd, shell=True)
 
 def clone(args):
     env = ZenDevEnvironment(srcroot=args.output, manifest=args.manifest)
@@ -501,6 +505,9 @@ def parse_args():
                               choices=['src', 'core', 'resmgr', 'svcpkg-core',
                                        'svcpkg-resmgr', 'serviced', 'devimg'])
     build_parser.set_defaults(functor=build)
+
+    devshell_parser = subparsers.add_parser('devshell')
+    devshell_parser.set_defaults(functor=devshell)
 
     drop_parser = subparsers.add_parser('drop')
     drop_parser.add_argument('name', metavar='ENVIRONMENT')


### PR DESCRIPTION
to aid debugging, zendev devshell should be equivalent to:
  docker run -v $(zendev root)/src:/mnt/src -v $(zendev root)/zenhome:/opt/zenoss -i -t zendev/devimg bash

DEMO:

```
# plu@plu-9: ls $(zendev root)/src
build            enterprise_zenpacks  metric-consumer   metric-tsdb     simulate  zauth-service                                         zep
check-rabbit.sh  europa               metric-publisher  protocols       utils     zenpacks                                              zproxy
core             golang               metric-service    serviced.shell  zapp      ZenPacks.zenoss.DistributedCollector-3.0.0-py2.7.egg
# plu@plu-9: ls $(zendev root)/zenhome
bin  export  import   lib    libexec         log       README.txt  supervisord.pid  webapps      ZenPacks  zproxy
etc  extras  include  lib64  License.zenoss  Products  share       var              zenjmx-libs  zopehome
# plu@plu-9: zendev devshell
bash-4.2# df -Ha /mnt/src /opt/zenoss
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda6       180G  8.6G  162G   6% /mnt/src
/dev/sda6       180G  8.6G  162G   6% /opt/zenoss
bash-4.2# ls /mnt/src
ZenPacks.zenoss.DistributedCollector-3.0.0-py2.7.egg  core         golang        metric-service  serviced.shell  zapp       zep
build                             enterprise_zenpacks  metric-consumer   metric-tsdb     simulate        zauth-service  zproxy
check-rabbit.sh                       europa           metric-publisher  protocols       utils       zenpacks
bash-4.2# ls /opt/zenoss
License.zenoss  README.txt  bin  export  import   lib    libexec  share        var      zenjmx-libs  zproxy
Products    ZenPacks    etc  extras  include  lib64  log      supervisord.pid  webapps  zopehome
```
