### PR TITLE
Feature/missing repo skip

### DIFF
--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -189,7 +189,7 @@ class ZenDevEnvironment(object):
             repo = Repository(path, fullpath, **info)
             yield repo
 
-    def repos(self, filter_=None, key=None):
+    def repos(self, filter_=None, key=None, includeMissing=False):
         """
         Get Repository objects for all repos in the system.
         """
@@ -342,7 +342,9 @@ class ZenDevEnvironment(object):
     def clone(self, shallow=False):
         cmd = 'shallow_clone' if shallow else 'clone'
         info("Cloning repositories")
-        self.foreach(cmd, lambda r: not r.repo, silent=not sys.stdout.isatty())
+        self.foreach(cmd, lambda r: not r.repo, 
+                     silent=not sys.stdout.isatty(), 
+                     includeMissing=True)
         info("All repositories are cloned!")
 
     def fetch(self):
@@ -475,11 +477,11 @@ class ZenDevEnvironment(object):
             info(" finish feature for repository: %s" % r.name)
             r.finish_feature( name)
 
-    def foreach(self, fname, filter_=None, silent=False):
+    def foreach(self, fname, filter_=None, silent=False, includeMissing=False):
         """
         Execute a method on all repositories in subprocesses.
         """
-        repos = list(self.repos(filter_))
+        repos = list(self.repos(filter_), includeMissing=includeMissing)
 
         if not repos:
             return

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -315,7 +315,7 @@ class ZenDevEnvironment(object):
     def ensure_build(self):
         if self.buildroot.check() and not is_git_repo(self.buildroot):
             error("%s exists but isn't a git repository. Not sure "
-                    "what to do." % self.buildroot)
+                  "what to do." % self.buildroot)
         else:
             repos = self.repos(lambda x: x.name==ZenDevEnvironment._buildrepo_name)
             if repos:

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -314,19 +314,21 @@ class ZenDevEnvironment(object):
         repo.repo.git.push('origin', ':%s' % name)
 
     def ensure_build(self):
-        repo = self.repos(lambda x: x.name == ZenDevEnvironment._buildrepo_name)[0]
-        builddir = repo.path
-        if builddir.check() and not is_git_repo(builddir):
+        if self.buildroot.check() and not is_git_repo(self.buildroot):
             error("%s exists but isn't a git repository. Not sure "
                   "what to do." % builddir)
         else:
-            if not builddir.check(dir=True):
+            repo = Repository('build', self.buildroot,
+                    repo='zenoss/platform-build',
+                    ref='develop')
+            if not self.buildroot.check(dir=True):
                 info("Checking out build repository")
                 repo.progress = SimpleGitProgressBar(repo.name)
                 repo.clone()
                 print
             else:
                 info("Build repository exists")
+            return repo
 
     def initialize(self):
         # Clone manifest directory

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -193,7 +193,8 @@ class ZenDevEnvironment(object):
         """
         Get Repository objects for all repos in the system.
         """
-        return sorted(itertools.ifilter(filter_, self._repos()), 
+        repoFilter = self._repo_filter(filter_) if not includeMissing else filter_
+        return sorted(itertools.ifilter(repoFilter, self._repos()), 
                 key=key or (lambda r:r.name.count('/')))
 
     def remove(self, filter_=None, save=True):
@@ -394,6 +395,8 @@ class ZenDevEnvironment(object):
         else:
           return lambda r : filter_(r) and feature_filter(r)
 
+    def _repo_filter(self, filter_=None):
+        return lambda r: r.repo and (filter_ is None or filter_(r))
 
     def start_feature(self, name, filter_=None):
         info("Starting feature: %s" % name)

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -101,7 +101,6 @@ class ZenDevEnvironment(object):
                 else self._root.join(ZenDevEnvironment._buildrepo_name))
         self._manifestroot = self._root.join('.manifest')
         self._manifest = create_manifest(manifest or self._config.join('manifest'))
-        self._add_build_repo(self._manifest, self._srcroot, self._buildroot)
         self._vagrant = VagrantManager(self)
         self._cluster = VagrantClusterManager(self)
         self._bash = open(os.environ.get('ZDCTLCHANNEL', os.devnull), 'w')
@@ -316,11 +315,9 @@ class ZenDevEnvironment(object):
     def ensure_build(self):
         if self.buildroot.check() and not is_git_repo(self.buildroot):
             error("%s exists but isn't a git repository. Not sure "
-                  "what to do." % builddir)
+                    "what to do." % self.buildroot)
         else:
-            repo = Repository('build', self.buildroot,
-                    repo='zenoss/platform-build',
-                    ref='develop')
+            repo = self.repos(lambda x: x.name==ZenDevEnvironment._buildrepo_name)[0]
             if not self.buildroot.check(dir=True):
                 info("Checking out build repository")
                 repo.progress = SimpleGitProgressBar(repo.name)
@@ -330,11 +327,14 @@ class ZenDevEnvironment(object):
                 info("Build repository exists")
             return repo
 
-    def initialize(self):
+    def initialize(self, skip_build_repo=False):
         # Clone manifest directory
         self.ensure_manifestrepo()
-        # Clone build directory
-        self.ensure_build()
+        if not skip_build_repo:
+            # add the default build repo
+            self._add_build_repo(self.manifest, self.srcroot, self.buildroot)
+            # Clone build directory
+            self.ensure_build()
 
     def clone(self, shallow=False):
         cmd = 'shallow_clone' if shallow else 'clone'

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -481,7 +481,7 @@ class ZenDevEnvironment(object):
         """
         Execute a method on all repositories in subprocesses.
         """
-        repos = list(self.repos(filter_), includeMissing=includeMissing)
+        repos = list(self.repos(filter_, includeMissing=includeMissing))
 
         if not repos:
             return

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -317,15 +317,17 @@ class ZenDevEnvironment(object):
             error("%s exists but isn't a git repository. Not sure "
                     "what to do." % self.buildroot)
         else:
-            repo = self.repos(lambda x: x.name==ZenDevEnvironment._buildrepo_name)[0]
-            if not self.buildroot.check(dir=True):
-                info("Checking out build repository")
-                repo.progress = SimpleGitProgressBar(repo.name)
-                repo.clone()
-                print
-            else:
-                info("Build repository exists")
-            return repo
+            repos = self.repos(lambda x: x.name==ZenDevEnvironment._buildrepo_name)
+            if repos:
+                repo = repos[0]
+                if not self.buildroot.check(dir=True):
+                    info("Checking out build repository")
+                    repo.progress = SimpleGitProgressBar(repo.name)
+                    repo.clone()
+                    print
+                else:
+                    info("Build repository exists")
+                return repo
 
     def initialize(self, skip_build_repo=False):
         # Clone manifest directory

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -394,10 +394,12 @@ def build(args):
         env.tag(args.createtag, strict=True)
     os.environ.update(env.envvars())
     with env.buildroot.as_cwd():
-        target = ['srcbuild' if t == 'src' else t for t in args.target]
         if args.clean:
             subprocess.call(["make", "clean"])
-        rc = subprocess.call(["make", "OUTPUT=%s" % args.output] + target)
+        makecmd = ['make']
+        if args.output:
+            makecmd += "OUTPUT=%s" % args.output
+        rc = subprocess.call(makecmd + args.target)
         sys.exit(rc)
 
 
@@ -493,14 +495,13 @@ def parse_args():
     build_parser.add_argument('-t', '--tag', metavar='TAG', required=False)
     build_parser.add_argument('-m', '--manifest', nargs="+",
                               metavar='MANIFEST', required=False)
-    build_parser.add_argument('-o', '--output', metavar='DIRECTORY',
-                              default=py.path.local().join('output').strpath)
+    build_parser.add_argument('-o', '--output', metavar='DIRECTORY', required=False)
     build_parser.add_argument('-c', '--clean', action="store_true",
                               default=False)
     build_parser.add_argument('--create-tag', dest="createtag", required=False,
                               help="Tag the source for this build")
     build_parser.add_argument('target', metavar='TARGET', nargs="+",
-                              choices=['src', 'core', 'resmgr', 'svcpkg-core',
+                              choices=['core', 'resmgr', 'svcpkg-core',
                                        'svcpkg-resmgr', 'serviced', 'devimg',
                                        'default'])
     build_parser.set_defaults(functor=build)

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -499,7 +499,8 @@ def parse_args():
                               help="Tag the source for this build")
     build_parser.add_argument('target', metavar='TARGET', nargs="+",
                               choices=['src', 'core', 'resmgr', 'svcpkg-core',
-                                       'svcpkg-resmgr', 'serviced', 'devimg'])
+                                       'svcpkg-resmgr', 'serviced', 'devimg',
+                                       'default'])
     build_parser.set_defaults(functor=build)
 
     drop_parser = subparsers.add_parser('drop')

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -186,12 +186,12 @@ def init(args):
         except NotInitialized:
             init_config_dir()
             env = ZenDevEnvironment(name=name, path=path)
+        env.initialize(args.no_build)
         env.manifest.save()
-        env.initialize()
         env.use()
-    if args.tag:
-        env.restore(args.tag)
-    return env
+        if args.tag:
+            env.restore(args.tag)
+        return env
 
 
 def add(args, paths=()):
@@ -481,6 +481,8 @@ def parse_args():
     init_parser = subparsers.add_parser('init')
     init_parser.add_argument('path', metavar="PATH")
     init_parser.add_argument('-t', '--tag', metavar="TAG", required=False)
+    init_parser.add_argument('-b', '--no-build', dest="no_build",
+                             action="store_true")
     init_parser.set_defaults(functor=init)
 
     use_parser = subparsers.add_parser('use')


### PR DESCRIPTION
Add a --no-build option to skip adding the default build repo at init time, and allowing for the 'build' dir to be an unmanaged directory. This is totally backwards-compatible, but enables some additional use cases.

Example: Using this script: https://github.com/zenoss/devbox-ubuntu/blob/master/salt/zenoss4x/bootstrap4x.sh

Also protect against the missing 'build' repo in the future - and missing repos in general. The Clone operation will still fill them in however!
