### PR TITLE
avoid obsolete apt-get dependency packaging lists cached in local docker...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu
 MAINTAINER Zenoss
 
-RUN apt-get update
-RUN apt-get -y install python wget make
+RUN apt-get update && apt-get -y install python wget make
 RUN wget --no-check-certificate -qO- https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
 RUN pip install sphinx
 WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu
 MAINTAINER Zenoss
 
+RUN apt-get update
 RUN apt-get -y install python wget make
 RUN wget --no-check-certificate -qO- https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
 RUN pip install sphinx


### PR DESCRIPTION
... images

Using fix discussed in this related thread:

   https://github.com/tianon/docker-brew-ubuntu-core/issues/7#issuecomment-47111169

To address busted zendev doc build:

   http://jenkins.zendev.org/view/All/job/zendev-docs/166/console

```
Err http://archive.ubuntu.com/ubuntu/ trusty-security/main openssl amd64 1.0.1f-1ubuntu2.3
  404  Not Found [IP: 91.189.88.153 80]
```
