### PR TITLE
mvn clean for metric-consumer and metric-service when zendev build devim...

### DIFF
--- a/zendev/cmd/build.py
+++ b/zendev/cmd/build.py
@@ -1,9 +1,9 @@
 import subprocess
 import sys
 import os
+import tempfile
 
 import py
-
 
 def build(args, env):
     srcroot = None
@@ -25,6 +25,11 @@ def build(args, env):
         target = ['srcbuild' if t == 'src' else t for t in args.target]
         if args.clean:
             subprocess.call(["make", "clean"])
+            for zapp in ["metric-consumer", "metric-service"]:
+                bashcommand = "cd /mnt/src/%s && pwd && mvn clean" % zapp
+                cmd = "docker run --privileged --rm -v %s/src:/mnt/src -i -t zenoss/rpmbuild:centos7 bash -c '%s'" % (
+                    env.root.strpath, bashcommand)
+                subprocess.call(cmd, shell=True)
         rc = subprocess.call(["make", "OUTPUT=%s" % args.output] + target)
         sys.exit(rc)
 


### PR DESCRIPTION
...g --clean

DEMO:

```
# plu@plu-9: zendev build devimg --clean
cd services && make clean
...

make[1]: Leaving directory `/home/plu/src/europa/build/services'
/mnt/src/metric-consumer
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] metric-consumer-parent
[INFO] metric-data
[INFO] metric-reporter
[INFO] metric-zapp-reporter
[INFO] metric-consumer-app
[INFO]                                                                         
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] metric-consumer-parent ............................ SUCCESS [1.003s]
[INFO] metric-data ....................................... SUCCESS [0.005s]
[INFO] metric-reporter ................................... SUCCESS [0.006s]
[INFO] metric-zapp-reporter .............................. SUCCESS [0.004s]
[INFO] metric-consumer-app ............................... SUCCESS [0.006s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

/mnt/src/metric-service
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building central-query 0.0.8-SNAPSHOT
[INFO] ------------------------------------------------------------------------
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.405s
[INFO] Finished at: Thu Aug 07 20:09:42 BST 2014
[INFO] Final Memory: 14M/481M
[INFO] ------------------------------------------------------------------------


```
