### PR TITLE
clean all toplevel java apps

### DIFF
--- a/zendev/cmd/build.py
+++ b/zendev/cmd/build.py
@@ -1,9 +1,9 @@
 import subprocess
 import sys
 import os
+import tempfile
 
 import py
-
 
 def build(args, env):
     srcroot = None
@@ -25,6 +25,10 @@ def build(args, env):
         target = ['srcbuild' if t == 'src' else t for t in args.target]
         if args.clean:
             subprocess.call(["make", "clean"])
+            bashcommand = "find /mnt/src/ -maxdepth 2 -name pom.xml|while read file; do (cd $(dirname $file) && echo -n cleaning: && pwd && mvn clean); done"
+            cmd = "docker run --privileged --rm -v %s/src:/mnt/src -i -t zenoss/rpmbuild:centos7 bash -c '%s'" % (
+                    env.root.strpath, bashcommand)
+            subprocess.call(cmd, shell=True)
         rc = subprocess.call(["make", "OUTPUT=%s" % args.output] + target)
         sys.exit(rc)
 


### PR DESCRIPTION
part 2 of:
  https://github.com/zenoss/zendev/pull/105

perhaps it should clean all java projects - but which ones - I favor only cleaning the top level via the list from the ls:

DEMO:

```
~/src/europa

# plu@plu-9: ls src/*/pom.xml
src/metric-consumer/pom.xml  src/metric-service/pom.xml  src/metric-tsdb/pom.xml  src/utils/pom.xml  src/zep/pom.xml

# plu@plu-9: find src -name pom.xml
src/core/Products/ZenUITests/tests/seleniumJavaRefactor/pom.xml
src/metric-consumer/pom.xml
src/metric-consumer/metric-consumer-app/pom.xml
src/metric-consumer/metric-reporter/pom.xml
src/metric-consumer/metric-data/pom.xml
src/metric-consumer/metric-zapp-reporter/pom.xml
src/zenpacks/ZenPacks.zenoss.ZenJMX/ZenPacks/zenoss/ZenJMX/pom.xml
src/metric-tsdb/pom.xml
src/metric-service/pom.xml
src/utils/pom.xml
src/enterprise_zenpacks/ZenPacks.zenoss.AutoTune/src/java/pom.xml
src/enterprise_zenpacks/ZenPacks.zenoss.CatalogService/src/java/pom.xml
src/enterprise_zenpacks/ZenPacks.zenoss.Impact/src/java/pom.xml
src/enterprise_zenpacks/ZenPacks.zenoss.DynamicView/src/java/pom.xml
src/enterprise_zenpacks/ZenPacks.zenoss.vSphere/src/txvsphere/java/pom.xml
src/zep/pom.xml
src/zep/core/pom.xml
src/zep/dist/pom.xml
src/zep/webapp/pom.xml
src/zapp/java/zenoss-app/pom.xml
src/zapp/java/pom.xml
src/zapp/java/zauth-bundle/pom.xml
src/zapp/java/zapp-example/pom.xml
src/zapp/java/zapp-archetypes/pom.xml
src/zapp/java/zapp-archetypes/java-simple/pom.xml
src/zapp/java/zapp-archetypes/java-simple/src/main/resources/archetype-resources/pom.xml
src/zapp/java/dw-spring-bundle/pom.xml
src/protocols/java/amqp-samples/pom.xml
src/protocols/java/pom.xml
src/protocols/java/amqp-api/pom.xml
src/protocols/java/protobufs/pom.xml

# plu@plu-9: zendev build devimg --clean 2>&1 | grep clean
cd services && make clean
cd repos && make clean
cd zenoss5x && make clean
cd opentsdb && make clean
        (cd ${product} && make clean) ;\
cleaning:/mnt/src/metric-consumer
Downloading: http://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.4.1/maven-clean-plugin-2.4.1.pom
Downloaded: http://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.4.1/maven-clean-plugin-2.4.1.pom (5 KB at 4.6 KB/sec)
Downloading: http://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.4.1/maven-clean-plugin-2.4.1.jar
Downloaded: http://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.4.1/maven-clean-plugin-2.4.1.jar (23 KB at 128.5 KB/sec)
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ metric-consumer-parent ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ metric-data ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ metric-reporter ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ metric-zapp-reporter ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ metric-consumer-app ---
cleaning:/mnt/src/metric-tsdb
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ metric-tsdb ---
cleaning:/mnt/src/metric-service
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ central-query ---
cleaning:/mnt/src/utils
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ zenoss-utils ---
cleaning:/mnt/src/zep
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ zep-parent ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ zep-core ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ zep-webapp ---
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ zep-dist ---
```
