### PR TITLE
fix none for template

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -158,7 +158,7 @@ class Serviced(object):
 
         compiled=json.loads(stdout);
         self.walk_services(compiled['Services'], self.zope_debug)
-        if 'resmgr' in template:
+        if template and 'resmgr' in template:
             self.walk_services(compiled['Services'], self.remove_catalogservice)
         stdout = json.dumps(compiled, sort_keys=True, indent=4, separators=(',', ': '))
 


### PR DESCRIPTION
ISSUE:

```
al/bin/zendev", line 9, in <module>
    load_entry_point('zendev==0.1.0', 'console_scripts', 'zendev')()
  File "/home/jhanson/src/zendev/zendev/zendev.py", line 142, in main
    args.functor(args, check_env)
  File "/home/jhanson/src/zendev/zendev/cmd/serviced.py", line 200, in run_serviced
    tplid = _serviced.add_template(args.template)
  File "/home/jhanson/src/zendev/zendev/cmd/serviced.py", line 161, in add_template
    if 'resmgr' in template:
TypeError: argument of type 'NoneType' is not iterable
jhanson@jhanson-desktop:~/src/europa/src/golang/src/github.com/control-center/serviced$ 2014/10/29 14:12:10 200 224.451us GET /servicehealth
2014/10/29 14:12:10 200 3.35584ms GET /services?since=4001
I1029 14:12:12.449657 0
```
