### PR TITLE
Handle broken data in ~/.zendev/environments.json

### DIFF
--- a/zendev/config.py
+++ b/zendev/config.py
@@ -11,7 +11,13 @@ class ZendevConfig(object):
         self._path = py.path.local(path)
         if self._path.check():
             with self._path.open() as f:
-                self._data = json.load(f)
+                try:
+                    self._data = json.load(f)
+                except ValueError as e:
+                    print "File %s has invalid JSON data: %s" % (f,e)
+                    self._data = {
+                       'environments':{}
+                    }
         else:
             self._data = {
                 'environments':{}


### PR DESCRIPTION
## Symptoms

When ~/.zendev/environments.json is empty or invalid there is an error:
https://gist.github.com/anonymous/7c9ebe7e1e9a761ed27c
## Resolution

Fix will check for valid Json and provide an error message if invalid.
