### PR TITLE
ensure $(zendev root)/var_zenoss/ZenPacks

### DIFF
--- a/zendev/cmd/build.py
+++ b/zendev/cmd/build.py
@@ -41,6 +41,7 @@ def build_zenoss(args, env):
             cmd = "docker run --privileged --rm -v %s/src:/mnt/src -i -t zenoss/rpmbuild:centos7 bash -c '%s'" % (
                     env.root.strpath, bashcommand)
             subprocess.call(cmd, shell=True)
+            env.var_zenoss.remove('ZenPacks')
 
         product = ''
         if args.resmgr:
@@ -51,6 +52,8 @@ def build_zenoss(args, env):
         packs = get_packs(env, product)
 
         if "devimg" in target:
+            env.var_zenoss.ensure('ZenPacks', dir=True)
+            env.var_zenoss.ensure('ZenPackSource', dir=True)
             os.environ['VAR_ZENOSS']=env.var_zenoss.strpath
             # Figure out which zenpacks to install.
             for pack in args.packs:


### PR DESCRIPTION
allow link installs to work for devimg

DEMO - from zendev build devimg --clean:

```
starting...
Waiting for zeneventserver to start......
Installing pack ZenPacks.zenoss.ZenJMX from /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX
WARNING:ZenUtils.ZopeRequestLogger:ERROR connecting to redis. redis URL: redis://localhost:6379/0
WARNING:ZenUtils.ZopeRequestLogger:Please check the redis-url value in global.conf
2014-12-19 22:08:13,901 INFO zen.ZPLoader: Loading /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX/ZenPacks/zenoss/ZenJMX/objects/objects.xml
2014-12-19 22:08:14,136 INFO zen.AddToPack: End loading objects
2014-12-19 22:08:14,136 INFO zen.AddToPack: Processing links
2014-12-19 22:08:14,270 INFO zen.AddToPack: Loaded 45 objects into the ZODB database
2014-12-19 22:08:14,308 INFO zen.HookReportLoader: Loading reports from /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX/ZenPacks/zenoss/ZenJMX/reports
'module' object has no attribute 'StrictRedis'
Creating /opt/zenoss/zenjmx-libs

Installing pack ZenPacks.zenoss.PythonCollector from /mnt/src/zenpacks/ZenPacks.zenoss.PythonCollector
WARNING:ZenUtils.ZopeRequestLogger:ERROR connecting to redis. redis URL: redis://localhost:6379/0
WARNING:ZenUtils.ZopeRequestLogger:Please check the redis-url value in global.conf
2014-12-19 22:08:27,543 INFO zen.ZPLoader: Loading /mnt/src/zenpacks/ZenPacks.zenoss.PythonCollector/ZenPacks/zenoss/PythonCollector/objects/objects.xml
2014-12-19 22:08:27,543 INFO zen.AddToPack: End loading objects
2014-12-19 22:08:27,543 INFO zen.AddToPack: Processing links
2014-12-19 22:08:27,564 INFO zen.AddToPack: Loaded 0 objects into the ZODB database
2014-12-19 22:08:27,603 INFO zen.HookReportLoader: Loading reports from /mnt/src/zenpacks/ZenPacks.zenoss.PythonCollector/ZenPacks/zenoss/PythonCollector/reports
'module' object has no attribute 'StrictRedis'
stopping...
```
