### PR TITLE
Include branches in zendev restore autocomplete

### DIFF
--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -297,7 +297,10 @@ class ZenDevEnvironment(object):
 
     def list_tags(self):
         repo = self.ensure_manifestrepo()
-        return repo.tag_names
+        # get local branch for each remote tracking branch
+        #   e.g., support/5.0.x for origin/support/5.0.x
+        local_branches = [i.split('/', 1)[1] for i in repo.remote_branches]
+        return repo.tag_names + local_branches
 
     def tag(self, name, strict=False, force=False, from_ref=None):
         self.refresh_manifests()


### PR DESCRIPTION
Include manifest remote tracking branches in list of environment tags.  (Motivating example: support/5.0.x)

This allows these branches to be viewed with _zendev tag --list_ or via tab-completion of _zendev restore_
