### PR TITLE
added zendev showrefs

### DIFF
--- a/zendev/cmd/environment.py
+++ b/zendev/cmd/environment.py
@@ -88,3 +88,4 @@ def add_commands(subparsers):
     which_parser = subparsers.add_parser('env', help='Print the current environment name')
     which_parser.set_defaults(functor=env)
 
+

--- a/zendev/cmd/repos.py
+++ b/zendev/cmd/repos.py
@@ -98,6 +98,14 @@ def each(args, env):
             error('%s is missing. Try "zendev sync" first.' % repo.name)
 
 
+def showrefs(args, env):
+    """
+    Show each repo's info
+    """
+    for repo in env().repos(args.repofilter):
+        print "%s %s" % (repo.name, repo.ref)
+
+
 def cd(args, env):
     """
     Print the directory of the repository if specified or the environment if
@@ -165,3 +173,8 @@ def add_commands(subparsers):
     cd_parser = subparsers.add_parser('cd', help='Change working directory to a repo')
     cd_parser.add_argument('repo', nargs='?', metavar="REPO")
     cd_parser.set_defaults(functor=cd)
+
+    showrefs_parser = subparsers.add_parser('showrefs', help='Show info of repos')
+    showrefs_parser.add_argument('-r', '--repo', dest="repos", nargs='*')
+    showrefs_parser.set_defaults(functor=showrefs)
+

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -87,7 +87,7 @@ def parse_args():
     epilog = textwrap.dedent('''
     Management commands: {bootstrap, root, selfupdate}
     Environment commands: {init, use, drop, clone, env}
-    Repo commands: {add, addrepo, rm, ls, freeze, sync, status, sync, cd}
+    Repo commands: {add, addrepo, rm, ls, freeze, sync, status, sync, cd, showrefs}
     Tag commands: {restore, tag, changelog}
     Serviced commands: {serviced, atttach, devshel}
     Vagrant commands {box, cluster, ssh}


### PR DESCRIPTION
Show the references from the manifest that match a keyword, e.g. support

TODO: add '-t' ('--tag') to checkout the manifest for the tag, show refs, then switch it back

DEMO - show refs for repos matching serviced:

```
# plu@plu-9: zendev showrefs --repo serviced
serviced.shell develop
golang/src/github.com/control-center/serviced support/1.0.x
```

DEMO - show refs and pipe to grep:

```
# plu@plu-9: zendev showrefs  | grep support
zep support/5.0.x
core support/5.0.x
service support/5.0.x
build support/5.0.x
protocols support/5.0.x
metric-service support/5.0.x
utils support/5.0.x
zauth-service support/5.0.x
zproxy support/5.0.x
metric-consumer support/5.0.x
golang/src/github.com/zenoss/zminion support/5.0.x
golang/src/github.com/zenoss/metricshipper support/5.0.x
golang/src/github.com/control-center/serviced support/1.0.x
```
