### PR TITLE
fixed infinite loop checking hostid while adding serviced host

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -87,11 +87,18 @@ class Serviced(object):
                 pass
 
     def add_host(self, host="172.17.42.1:4979", pool="default"):
-        err = None
-        while err != "":
+        hostid = None
+        while not hostid:
             time.sleep(1)
-            process = subprocess.Popen([self.serviced, "host","add", host, pool], stderr=subprocess.PIPE)
-            _, err = process.communicate()
+            process = subprocess.Popen([self.serviced, "host","add", host, pool], stdout=subprocess.PIPE)
+            out, _ = process.communicate()
+            if out:
+                ahostid = out.rstrip()
+                process = subprocess.Popen([self.serviced, "host", "list", ahostid], stdout=subprocess.PIPE)
+                out, _ = process.communicate()
+                if ahostid in out:
+                    hostid = ahostid
+                    print "Added hostid %s for host %s  pool %s" % (hostid, host, pool)
 
     def deploy(self, template, pool="default", svcname="HBase",
             noAutoAssignIpFlag=""):


### PR DESCRIPTION
ISSUE - seen infinitely with "zendev serviced -dx":

```
WARNING: could read default configs: open /etc/default/serviced: no such file or directory
I0428 20:05:14.650762 29012 agent.go:52] local static ips [] [0]
I0428 20:05:14.661258 29012 host.go:147] building with ipsAddrs: [172.17.42.1] [1]
I0428 20:05:14.662118 29012 utils.go:134] looking for '172.17.42.1'
```

DEMO - no more infinite loop and added hostid message is shown:

```
serviced is ready!
WARNING: could read default configs: open /etc/default/serviced: no such file or directory
I0428 20:05:14.650762 29012 agent.go:52] local static ips [] [0]
I0428 20:05:14.661258 29012 host.go:147] building with ipsAddrs: [172.17.42.1] [1]
I0428 20:05:14.662118 29012 utils.go:134] looking for '172.17.42.1'
WARNING: could read default configs: open /etc/default/serviced: no such file or directory
Added hostid 570a276e for host 172.17.42.1:4979  pool default
Adding template
```
