### PR TITLE
Modify impact-devimg to link to correct war file

### DIFF
--- a/zendev/cmd/build.py
+++ b/zendev/cmd/build.py
@@ -88,7 +88,7 @@ def build_impact(args, env):
         SRC=/mnt/src/impact/impact-server
         DST=/opt/zenoss_impact
         VSN=5.0.70.0.0-SNAPSHOT
-        ln -fs $SRC/zenoss-dsa/target/zenoss-dsa-$VSN.war $DST/webapps/impact-server.war
+        ln -fs $SRC/zenoss-dsa/target/impact-server.war $DST/webapps/impact-server.war
         ln -fs $SRC/model-adapters-common/target/model-adapters-common-$VSN.jar $DST/lib/ext/adapters
         ln -fs $SRC/model-adapters-zenoss/target/model-adapters-zenoss-$VSN.jar $DST/lib/ext/adapters/zenoss
     """


### PR DESCRIPTION
WAR file was renamed due to requirements of updated Jetty version

See also https://github.com/zenoss/impact-server/pull/151
