### PR TITLE
show repo push to help with traceback debugging

### DIFF
--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -377,6 +377,7 @@ class ZenDevEnvironment(object):
             repo.merge_from_remote()
         info("Remote changes have been merged")
         for repo in self.repos(filter_):
+            info("Pushing %s" % repo.name)
             repo.push()
         info("Up to date!")
 


### PR DESCRIPTION
show pushing of repo for zendev restore to help with traceback debugging.

ISSUE:

```
# plu@plu-9: zendev restore support/5.0.x
...
==> Syncing golang/src/github.com/control-center/serviced
==> Remote changes have been merged
Traceback (most recent call last):
  File "/usr/local/bin/zendev", line 9, in <module>
    load_entry_point('zendev==0.1.0', 'console_scripts', 'zendev')()
  File "/home/plu/src/zendev/zendev/zendev.py", line 153, in main
    args.functor(args, check_env)
  File "/home/plu/src/zendev/zendev/cmd/tags.py", line 45, in restore
    env().restore(args.name)
  File "/home/plu/src/zendev/zendev/environment.py", line 287, in restore
    self.sync(force_branch=True, shallow=shallow)
  File "/home/plu/src/zendev/zendev/environment.py", line 380, in sync
    repo.push()
  File "/home/plu/src/zendev/zendev/repo.py", line 201, in push
    output = self.repo.git.rev_list(local_name, '--not', '--remotes')
  File "/usr/local/lib/python2.7/dist-packages/git/cmd.py", line 227, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/git/cmd.py", line 456, in _call_process
    return self.execute(call, **_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/git/cmd.py", line 335, in execute
    **subprocess_kwargs
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
IOError: [Errno 25] Inappropriate ioctl for device
```

DEMO:

```
# plu@plu-9: zendev restore support/5.0.x
==> Cloning repositories
...
==> Syncing golang/src/github.com/control-center/serviced
==> Remote changes have been merged
==> Pushing zep
...
==> Pushing golang/src/github.com/control-center/serviced
==> Up to date!
==> Manifest 'support/5.0.x' has been restored
```
