### PR TITLE
Don't remove zencatalogservice if not using devimg

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -187,7 +187,7 @@ class Serviced(object):
 
         compiled=json.loads(stdout);
         self.walk_services(compiled['Services'], self.zope_debug)
-        if template and ('ucspm' in template or 'resmgr' in template):
+        if 'devimg' in image:
             self.walk_services(compiled['Services'], self.remove_catalogservice)
         stdout = json.dumps(compiled, sort_keys=True, indent=4, separators=(',', ': '))
         return stdout


### PR DESCRIPTION
Previously would remove zencatalogservice for all ucspm or resmgr templates; now only does so if not using devimg.  This allows commands including a non-standard image to work with resmgr templates.  E.g.,

```
$ zendev serviced -dx --template Zenoss.resmgr.lite --image zenoss/resmgr_5.1:5.1.1_2550_unstable
```
