### PR TITLE
Fix docker-docs makefile target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu
 MAINTAINER Zenoss
 
 RUN apt-get update && apt-get -y install python wget make
-RUN wget --no-check-certificate -qO- https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
+RUN wget --no-check-certificate -qO- https://bootstrap.pypa.io/get-pip.py | python
 RUN pip install sphinx
 WORKDIR /docs

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ docs: _docs
 
 docker-docs:
 	docker build -t zenoss/zendev-docs-build .
-	docker run -rm -v $${PWD}:/zendev zenoss/zendev-docs-build bash -c "cd /zendev; pip install -e .; make _docs; chown -R $$(id -u) /zendev/docs"
+	docker run --rm -v $${PWD}:/zendev zenoss/zendev-docs-build bash -c "cd /zendev; pip install -e .; make _docs; chown -R $$(id -u) /zendev/docs"
 
 publish-docs: 
 	rm -rf /tmp/zendev-docs


### PR DESCRIPTION
1) Use --rm docker arg instead of obsolete -rf form
2) Use authoritative version of get-pip.py
