### PR TITLE
don't set the allow-loopback flag in 1.1.0

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -66,8 +66,9 @@ class Serviced(object):
           args.extend(arguments)
         # In serviced 1.1 and later, use subcommand 'server' to specifically request serviced be started
         servicedVersion = subprocess.check_output("%s version | awk '/^Version:/ { print $NF; exit }'" % self.serviced, shell=True).strip()
-        if not servicedVersion.startswith("1.0."):
+        if not servicedVersion.startswith("1.0.") and servicedVersion != "1.1.0":
             args.extend(["--allow-loop-back", "true"])
+        if not servicedVersion.startswith("1.0."):
             args.extend(["server"])
 
         print "Running command:", args


### PR DESCRIPTION
1.1.0 also doesn't have the allow-loopback stuff, so it blows up. This skips that flag in 1.1.0.
