### PR TITLE
when attaching to a container set the term variable to something reasonable

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -313,7 +313,7 @@ def run_serviced(args, env):
 
 
 def attach(args, env):
-    subprocess.call("serviced service attach '%s'; stty sane" % args.specifier, shell=True)
+    subprocess.call("serviced service attach '%s'  /bin/bash -c 'export TERM=xterm; exec bash'" % args.specifier, shell=True)
 
 
 def devshell(args, env):


### PR DESCRIPTION
no more having to manually set your term
