### PR TITLE
Build/use a devimg per environment 

### DIFF
--- a/zendev/cmd/build.py
+++ b/zendev/cmd/build.py
@@ -61,6 +61,7 @@ def build_zenoss(args, env):
             env.var_zenoss.ensure('ZenPacks', dir=True)
             env.var_zenoss.ensure('ZenPackSource', dir=True)
             os.environ['VAR_ZENOSS']=env.var_zenoss.strpath
+            os.environ['devimg_TAGNAME']='zendev/devimg:' + env.name
             # Figure out which zenpacks to install.
             for pack in args.packs:
                 if not pack.startswith("ZenPacks"):

--- a/zendev/cmd/test.py
+++ b/zendev/cmd/test.py
@@ -6,12 +6,19 @@ import os
 from zendev.cmd.build import get_packs
 
 
-def check_devimg():
-    has_devimg = subprocess.check_output('docker images -q zendev/devimg'.split()) != ''
-    if not has_devimg:
-        print >> sys.stderr, ("You don't have the devimg built. Please run"
-                              " zendev build devimg\" first.")
-        sys.exit(1)
+def check_devimg(env):
+    """
+    return the image repo/tag for devimg
+    prefer the image for this environment if one exists; otherwise the latest
+    exit the program with a warning if no image is available
+    """
+    for tag in (env.name, 'latest'):
+        devimg = 'zendev/devimg:' + tag
+        if subprocess.check_output(['docker', 'images', '-q', devimg]) != '':
+            return devimg
+    print >> sys.stderr, ("You don't have the devimg built. Please run"
+                          " zendev build devimg\" first.")
+    sys.exit(1)
 
 
 def check_zendev_test():
@@ -34,8 +41,7 @@ def zen_image_tests(args, env, product=''):
     mounts[env.var_zenoss.strpath] = "/var/zenoss"
     image = "zendev_test"
     if product == 'devimg':
-        check_devimg()
-        image = "zendev/devimg"
+        image = check_devimg(env)
         mounts[os.path.join(envvars["ZENHOME"])] = "/opt/zenoss"
     elif not args.use_existing or (args.use_existing and not check_zendev_test()):
         # Run a build
@@ -84,9 +90,7 @@ def zep_tests(args, env):
     envvars = os.environ.copy()
     envvars.update(env.envvars())
     mounts = {envvars["SRCROOT"]: "/mnt/src", env.buildroot: "/mnt/build"}
-    image = "zendev_test"
-    check_devimg()
-    image = "zendev/devimg"
+    image = check_devimg(env)
     mounts[os.path.join(envvars["HOME"], ".m2")] = "/home/zenoss/.m2"
     mounts[os.path.join(envvars["ZENHOME"])] = "/opt/zenoss"
 


### PR DESCRIPTION
Create and use a devimg per environment.  This allows users to switch
between environments without having to rebuild devimg each time.
