### PR TITLE
Change tmux window name

### DIFF
--- a/zendev/cmd/build.py
+++ b/zendev/cmd/build.py
@@ -6,6 +6,7 @@ import tempfile
 import uuid
 import py
 from ..log import error
+from ..utils import rename_tmux_window
 
 packlists = {
         'resmgr': 'pkg/zenoss_resmgr_zenpacks.mk',
@@ -14,6 +15,7 @@ packlists = {
     }
 
 def build(args, env):
+    rename_tmux_window("build")
     if "impact-devimg" in args.target:
         build_impact(args, env)
     elif "analytics-devimg" in args.target:

--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -11,7 +11,7 @@ import py.path
 import requests
 from vagrantManager import VagrantManager
 from ..log import info
-from ..utils import get_ip_address
+from ..utils import get_ip_address, rename_tmux_window
 
 class Serviced(object):
 
@@ -49,6 +49,7 @@ class Serviced(object):
 
     def start(self, root=False, uiport=443, arguments=None, registry=False, cluster_master=False, image=None):
         print "Starting serviced..."
+        rename_tmux_window("serviced")
         self.uiport = uiport
         args = []
         envvars = self.env.envvars()
@@ -328,6 +329,7 @@ def run_serviced(args, env):
 
 
 def attach(args, env):
+    rename_tmux_window(args.specifier)
     subprocess.call("serviced service attach '%s'; stty sane" % args.specifier, shell=True)
 
 
@@ -337,6 +339,8 @@ def devshell(args, env):
     """
     env = env()
     _serviced = env._gopath.join("bin/serviced").strpath
+
+    rename_tmux_window("devshell")
 
     command = "su - zenoss"
     if args.command:

--- a/zendev/utils.py
+++ b/zendev/utils.py
@@ -7,6 +7,7 @@ import json
 import socket
 import requests
 from termcolor import colored as colored_orig
+import subprocess
 
 _COLORS = not os.environ.get("ZENDEV_COLORS", '').lower() in ('0', 'false', 'no', 'none')
 
@@ -123,3 +124,12 @@ def get_ip_address():
         return None
     finally:
         del s
+
+
+def rename_tmux_window(name=None):
+    """
+    Inside tmux renames current window.
+    """
+    if os.environ.get("TMUX") and name:
+        subprocess.call("tmux rename-window {} >/dev/null 2>&1".format(name), shell=True)
+


### PR DESCRIPTION
I found it useful, to rename tmux window according to zendev subcommand being running inside.
