### PR TITLE
add thin-provisioning-tools as dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,7 +72,7 @@ Ubuntu
     .. code-block:: bash
 
         # Install lvm tools
-        sudo apt-get install lvm2
+        sudo apt-get install lvm2 thin-provisioning-tools
 
 
     The development machine you were provided should have a second hard drive


### PR DESCRIPTION
Running on 16.04, I hit the issue in http://serverfault.com/questions/718349/freshly-created-lvs-do-not-survive-reboot-check-of-thinpool-failed (bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=773731). Fix is to install thin-provisioning-tools.
