### PR TITLE
Change version of Docker for Ubuntu 16.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ docs/_build
 docs/_themes
 docs/modules.rst
 docs/zendev.rst
+docs/zendev.cmd.rst
+docs/zendev.monkey_patch.rst
 
 # Vagrant
 packer_cache

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,7 +61,7 @@ Ubuntu
             > /etc/apt/sources.list.d/docker.list"
         sudo apt-get update
         sudo apt-get purge lxc-docker*
-        sudo apt-get install docker-engine=1.9.1-0~$(lsb_release -sc)
+        sudo apt-get install docker-engine=1.11.1-0~$(lsb_release -sc)
 
         # Lock the version of Docker so updates won't bump it to a newer version
         sudo apt-mark hold docker-engine


### PR DESCRIPTION
- Docker removed support for 1.0.9 in Ubuntu 16.04
- Add 2 temporary files in docs to .gitignore
