### PR TITLE
Initial integration with jig

### DIFF
--- a/zendev/cmd/tags.py
+++ b/zendev/cmd/tags.py
@@ -1,0 +1,14 @@
+
+from ..log import error
+
+
+def restore(args, env):
+    env().restore(args.name)
+
+def add_commands(subparsers, completer):
+    restore_parser = subparsers.add_parser('restore', help='Restore repository state to a tag')
+    a = restore_parser.add_argument('name', metavar="NAME")
+    a.completer = completer
+    restore_parser.set_defaults(functor=restore)
+
+    # TODO: add support for tag and changelog ala zendev v1

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -8,7 +8,7 @@ from .utils import here, colored
 from .environment import ZenDevEnvironment
 from .environment import NotInitialized
 
-from .cmd import serviced, environment, build, devimg
+from .cmd import build, devimg, environment, serviced, tags
 
 from .config import get_config, get_envname
 
@@ -40,6 +40,7 @@ def parse_args():
 
     # Add sub commands here
     environment.add_commands(subparsers)
+    tags.add_commands(subparsers, tagsCompleter)
     serviced.add_commands(subparsers)
     build.add_commands(subparsers)
     devimg.add_commands(subparsers)
@@ -61,6 +62,10 @@ def root(args, env):
 
 def bootstrap(args, env):
     print here("bootstrap.sh").strpath
+
+
+def tagsCompleter(prefix, **kwargs):
+    return (x for x in check_env().list_tags() if x.startswith(prefix))
 
 
 def ls(args, env):


### PR DESCRIPTION
There are several TODOs in this PR, but I wanted to get some initial feedback before proceeding.

The full setup instructions for zendev, v2 are still TBD, but at a minimum they need to include `go get github.com/iancmcc/jig`

With these changes:
- `zendev init myEnv` should checkout everything to `./myEnv/src/...` 
- `zendev restore develop` will checkout everything based on the develop branch of product-assembly.

Actually, the last command will always do that - one of the TODOs is to switch to the target branch of product-assembly before generating the list of repos.
