### PR TITLE
initial version of the test command

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -9,6 +9,7 @@ import re
 import py.path
 import requests
 from ..log import info
+from ..devimage import DevImage
 from ..utils import get_ip_address, rename_tmux_window
 
 class Serviced(object):
@@ -20,15 +21,12 @@ class Serviced(object):
         self.env = env
         self.serviced = self.env.gopath.join("bin/serviced").strpath
         self.uiport = None
+        self.dev_image = DevImage(env)
 
     def get_zenoss_image(self, zenoss_image):
         if zenoss_image != 'zendev/devimg':
             return zenoss_image
-        zenoss_image += ':' + self.env.name
-        image_id = subprocess.check_output(['docker', 'images', '-q', zenoss_image])
-        if image_id:
-            return zenoss_image
-        return 'zendev/devimg:latest'
+        return self.dev_image.get_image_name()
 
     def reset(self):
         print "Stopping any running serviced"
@@ -41,6 +39,12 @@ class Serviced(object):
         subprocess.call("sudo rm -rf %s/*" % self.env.servicedhome.strpath, shell=True)
 
     def start(self, root=False, uiport=443, arguments=None, image=None):
+        devimg_name = self.get_zenoss_image(image)
+        if not self.dev_image.image_exists(devimg_name):
+            print >> sys.stderr, ("You don't have the devimg built. Please run"
+                      " zendev devimg\" first.")
+            sys.exit(1)
+
         print "Starting serviced..."
         rename_tmux_window("serviced")
         self.uiport = uiport
@@ -52,17 +56,18 @@ class Serviced(object):
         if root:
             args.extend(["sudo", "-E"])
             args.extend("%s=%s" % x for x in envvars.iteritems())
-        devimg = self.get_zenoss_image(image)
-        args.extend([self.serviced,
-            "--mount", "%s,%s,/home/zenoss/.m2" % (devimg, py.path.local(os.path.expanduser("~")).ensure(".m2", dir=True)),
-            "--mount", "%s,%s,/opt/zenoss" % (devimg, self.env.root.join("zenhome").strpath),
-            "--mount", "%s,%s,/mnt/src" % (devimg, self.env.root.join("src/github.com/zenoss").strpath),
-            "--mount", "%s,%s,/var/zenoss" % (devimg, self.env.var_zenoss.strpath),
+
+        args.extend([self.serviced])
+        mounts = self.dev_image.get_mounts()
+        for mount in mounts.iteritems():
+            args.extend(["--mount", "%s,%s,%s" % (devimg_name, mount[0], mount[1])])
+        args.extend([
             "--mount", "zendev/impact-devimg,%s,/mnt/src" % self.env.root.join("src").strpath,
             "--uiport", ":%d" % uiport,
         ])
         if arguments:
           args.extend(arguments)
+
         # In serviced 1.1 and later, use subcommand 'server' to specifically request serviced be started
         servicedVersion = subprocess.check_output("%s version | awk '/^Version:/ { print $NF; exit }'" % self.serviced, shell=True).strip()
         if not servicedVersion.startswith("1.0.") and servicedVersion != "1.1.0":
@@ -298,7 +303,7 @@ def run_serviced(args, env):
             print "Not ready yet (countdown:%d). Checking again in 1 second." % timeout
             time.sleep(1)
             timeout -= 1
-        
+
 
         if wait_for_ready:
             print "serviced is ready!"

--- a/zendev/cmd/test.py
+++ b/zendev/cmd/test.py
@@ -1,0 +1,73 @@
+import argparse
+import subprocess
+import sys
+import os
+
+
+def check_devimg(env):
+    """
+    return the image repo/tag for devimg
+    prefer the image for this environment if one exists; otherwise the latest
+    exit the program with a warning if no image is available
+    """
+    for tag in (env.name, 'latest'):
+        devimg = 'zendev/devimg:' + tag
+        if subprocess.check_output(['docker', 'images', '-q', devimg]) != '':
+            return devimg
+    print >> sys.stderr, ("You don't have the devimg built. Please run"
+                          " zendev devimg\" first.")
+    sys.exit(1)
+
+def get_mounts(env):
+    """
+    return a map of mount points in the form of
+    OS-local-directory-name:container-local-directory-name
+    """
+    envvars = env.envvars()
+    envvars['HOME'] = os.getenv('HOME')
+    print "envvars=%s" % envvars
+    mounts = {
+        os.path.join(envvars["HOME"], ".m2"):           "/home/zenoss/.m2",
+        env.root.join("zenhome").strpath:               "/opt/zenoss",
+        env.var_zenoss.strpath:                         "/var/zenoss",
+        env.root.join("src/github.com/zenoss").strpath: "/mnt/src"
+    }
+    return mounts
+
+def test(args, env):
+    cmd = ["docker", "run", "-i", "-t", "--rm"]
+    if args.no_tty:
+        cmd.remove("-t")
+
+    env = env()
+    mounts = get_mounts(env)
+    for mount in mounts.iteritems():
+        cmd.extend(["-v", "%s:%s" % mount])
+
+    image = check_devimg(env)
+    cmd.append(image)
+
+    if args.interactive:
+        cmd.append('bash')
+    else:
+        cmd.append("/opt/zenoss/install_scripts/starttests.sh")
+        cmd.extend(args.arguments[1:])
+
+    print "Using %s image." % image
+    print "Calling Docker with the following:"
+    print " ".join(cmd)
+    return subprocess.call(cmd)
+
+
+def add_commands(subparsers):
+    test_parser = subparsers.add_parser('test', help="Run Zenoss product tests")
+
+    test_parser.add_argument('-i', '--interactive', action="store_true",
+            help="Start an interactive shell instead of running the test",
+            default=False)
+    test_parser.add_argument('-n', '--no-tty', action="store_true",
+            help="Do not allocate a TTY",
+            dest="no_tty",
+            default=False)
+    test_parser.add_argument('arguments', nargs=argparse.REMAINDER)
+    test_parser.set_defaults(functor=test)

--- a/zendev/devimage.py
+++ b/zendev/devimage.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+
+
+class DevImage(object):
+    """
+    Represents an instance of zendev/devimg.
+    """
+    def __init__(self, env):
+        self.env = env
+
+    def get_image_name(self):
+        zenoss_image = 'zendev/devimg:' + self.env.name
+        image_id = subprocess.check_output(['docker', 'images', '-q', zenoss_image])
+        if image_id:
+            return zenoss_image
+        return 'zendev/devimg:latest'
+
+    def image_exists(self, imageName):
+        """
+        return the image repo/tag for devimg
+        prefer the image for this environment if one exists; otherwise the latest
+        exit the program with a warning if no image is available
+        """
+        if subprocess.check_output(['docker', 'images', '-q', imageName]) != '':
+            return True
+        return False
+
+    def get_mounts(self):
+        """
+        return a map of mount points in the form of
+        OS-local-directory-name:container-local-directory-name
+        """
+        envvars = self.env.envvars()
+        envvars['HOME'] = os.getenv('HOME')
+        mounts = {
+            os.path.join(envvars["HOME"], ".m2"):           "/home/zenoss/.m2",
+            self.env.root.join("zenhome").strpath:               "/opt/zenoss",
+            self.env.var_zenoss.strpath:                         "/var/zenoss",
+            self.env.root.join("src/github.com/zenoss").strpath: "/mnt/src"
+        }
+        return mounts
+

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -8,7 +8,7 @@ from .utils import here, colored
 from .environment import ZenDevEnvironment
 from .environment import NotInitialized
 
-from .cmd import build, devimg, environment, repos, serviced, tags
+from .cmd import build, devimg, environment, repos, serviced, tags, test
 
 from .config import get_config, get_envname
 from .log import error
@@ -41,6 +41,7 @@ def parse_args():
     tags.add_commands(subparsers, tagsCompleter)
     build.add_commands(subparsers)
     devimg.add_commands(subparsers)
+    test.add_commands(subparsers)
     repos.add_commands(subparsers)
     serviced.add_commands(subparsers)
 


### PR DESCRIPTION
Requires changes in https://github.com/zenoss/product-assembly/pull/62

**Examples:**

Run all of the tests in the current devimg, including any zenpacks (in this case, core zenpacks)

```
zendev devimg --clean -p core
zendev test
```

Run just the prodbin tests

```
zendev devimg --clean
zendev test -- --no-zenpacks
```

Run tests for a single ZenPack

```
zendev devimg --clean -p core
zendev test -- --type=unit --name ZenPacks.zenoss.LinuxMonitor
```
