### PR TITLE
make zendev logs more distinct from surrounding output

### DIFF
--- a/zendev/cmd/serviced.py
+++ b/zendev/cmd/serviced.py
@@ -367,9 +367,9 @@ def run_serviced(args, env):
             info("Starting all services");
             # Join the subprocess
 
-	# subtle hint that zenoss is
-	# ready to use
-	print """
+        # subtle hint that zenoss is
+        # ready to use
+        print """
  __________ _   _ ____  _______     __
 |__  / ____| \ | |  _ \| ____\ \   / /
   / /|  _| |  \| | | | |  _|  \ \ / /

--- a/zendev/log.py
+++ b/zendev/log.py
@@ -4,17 +4,17 @@ from .utils import colored
 
 def info(msg):
     if sys.stdout.isatty():
-        print >> sys.stderr, colored('==>', 'blue'), colored(msg, 'white')
+        print >> sys.stderr, colored('ZENDEV:', 'magenta'), colored(msg, 'magenta')
     else:
         print >> sys.stderr, msg
 
 def error(msg):
     if sys.stdout.isatty():
-        print >> sys.stderr, colored('==>', 'red'), colored(msg, 'white')
+        print >> sys.stderr, colored('ZENDEV:', 'red'), colored(msg, 'red')
     else:
         print >> sys.stderr, msg
 
 def ask(msg, response):
-    print >> sys.stderr, colored('==>', 'green'), colored(msg, 'white')
-    print >> sys.stderr, colored('==>', 'green'), colored(response, 'white')
+    print >> sys.stderr, colored('ZENDEV:', 'green'), colored(msg, 'white')
+    print >> sys.stderr, colored('ZENDEV:', 'green'), colored(response, 'white')
     return raw_input()


### PR DESCRIPTION
It's difficult to know what zendev is doing exactly when its deploying serviced and zenoss. These changes make it clearer by making zendev log messages distinct from serviced log messages.

![image](https://cloud.githubusercontent.com/assets/1927558/18716380/4196c4be-7fe2-11e6-8199-093ae2c66cd7.png)
