### PR TITLE
Add zendev dump-zodb to clean and dump zodb

### DIFF
--- a/zendev/cmd/dumpzodb.py
+++ b/zendev/cmd/dumpzodb.py
@@ -1,8 +1,6 @@
 import subprocess
 
 def dumpzodb(args, env):
-    
-
     environ = env()
     cmdArgs = ['make']
     cmdArgs.append('dumpdb')
@@ -13,14 +11,11 @@ def dumpzodb(args, env):
     if not args.gz:
         cmdArgs.append('ZENWIPE_ARGS=--xml')
 
-
-
     devimgSrcDir = environ.productAssembly.join("devimg")
     print "cd %s" % devimgSrcDir.strpath
     devimgSrcDir.chdir()
     print " ".join(cmdArgs)
     subprocess.check_call(cmdArgs)
-
 
 def add_commands(subparsers):
     epilog = '''
@@ -30,12 +25,10 @@ def add_commands(subparsers):
     and then run:
     zendev dump-zodb
     '''
-    
-    dumpzodb_parser = subparsers.add_parser('dump-zodb', help="Manage zodb", epilog=epilog)
 
+    dumpzodb_parser = subparsers.add_parser('dump-zodb', help="Manage zodb", epilog=epilog)
     dumpzodb_parser.add_argument('-z', '--load-from-gz', action="store_true",
             help="Load data from the .gz file instead of the .xml files",
             dest="gz",
             default=False)
-
     dumpzodb_parser.set_defaults(functor=dumpzodb)

--- a/zendev/cmd/dumpzodb.py
+++ b/zendev/cmd/dumpzodb.py
@@ -1,0 +1,41 @@
+import subprocess
+
+def dumpzodb(args, env):
+    
+
+    environ = env()
+    cmdArgs = ['make']
+    cmdArgs.append('dumpdb')
+    cmdArgs.append("ZENDEV_ROOT=%s" % environ.root.strpath)
+    cmdArgs.append("SRCROOT=%s" % environ.srcroot.join("github.com", "zenoss").strpath)
+    cmdArgs.append('DEV_ENV=%s' % environ.name)
+
+    if not args.gz:
+        cmdArgs.append('ZENWIPE_ARGS=--xml')
+
+
+
+    devimgSrcDir = environ.productAssembly.join("devimg")
+    print "cd %s" % devimgSrcDir.strpath
+    devimgSrcDir.chdir()
+    print " ".join(cmdArgs)
+    subprocess.check_call(cmdArgs)
+
+
+def add_commands(subparsers):
+    epilog = '''
+    To dump clean, updated database files to Products/ZenModel/data, 
+    build a core devimg with: 
+    zendev devimg --clean 
+    and then run:
+    zendev dump-zodb
+    '''
+    
+    dumpzodb_parser = subparsers.add_parser('dump-zodb', help="Manage zodb", epilog=epilog)
+
+    dumpzodb_parser.add_argument('-z', '--load-from-gz', action="store_true",
+            help="Load data from the .gz file instead of the .xml files",
+            dest="gz",
+            default=False)
+
+    dumpzodb_parser.set_defaults(functor=dumpzodb)

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -9,7 +9,7 @@ from .utils import here, colored
 from .environment import ZenDevEnvironment
 from .environment import NotInitialized
 
-from .cmd import build, devimg, environment, repos, serviced, tags, test
+from .cmd import build, devimg, environment, repos, serviced, tags, test, dumpzodb
 
 from .config import get_config, get_envname
 from .log import error
@@ -18,7 +18,7 @@ def parse_args():
     epilog = textwrap.dedent('''
     Environment commands: {init, ls, use, drop, env, root}
     Repo commands: {cd, restore, status, pull}
-    Serviced commands: {serviced, atttach, devshell}
+    Serviced commands: {serviced, atttach, devshell, dump-zodb}
     ''')
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, epilog=epilog)
@@ -48,6 +48,7 @@ def parse_args():
     test.add_commands(subparsers)
     repos.add_commands(subparsers)
     serviced.add_commands(subparsers)
+    dumpzodb.add_commands(subparsers)
 
     argcomplete.autocomplete(parser)
 


### PR DESCRIPTION
```
$ zendev dump-zodb --help
usage: zendev dump-zodb [-h] [-z]

optional arguments:
  -h, --help          show this help message and exit
  -z, --load-from-gz  Load data from the .gz file instead of the .xml files

To dump clean, updated database files to Products/ZenModel/data, build a core
devimg with: zendev devimg --clean and then run: zendev dump-zodb
```