### PR TITLE
Set gitflow branch repo configuration

### DIFF
--- a/zendev/repo.py
+++ b/zendev/repo.py
@@ -108,6 +108,8 @@ class Repository(object):
             self._repo = gitflow.core.GitFlow(self.path.strpath)
         if self._repo and not self._repo.is_initialized():
             py.io.StdCaptureFD.call(self._repo.init)
+        if self._repo and not self._repo.get('include.path', ''):
+            self._repo.set('include.path', '../gitflow-branch-config')
 
 
                      

--- a/zendev/zendev.py
+++ b/zendev/zendev.py
@@ -63,6 +63,13 @@ def selfupdate(args, env):
         env.update(os.environ)
         env['GOPATH'] = env['HOME']
         subprocess.call(["go", "get", "-u", "github.com/iancmcc/jig"], env=env)
+    # Initialize all repos for all environments.  This is to ensure that repos
+    # created without a branch.path config value are updated to include that.
+    config = get_config()
+    for env_name in config.environments:
+        env = check_env(env_name)
+        for repo in env.repos():
+            repo.initialize()
 
 
 def root(args, env):


### PR DESCRIPTION
Automatically perform the [zenoss git-flow repo configuration](https://docs.google.com/document/d/1iieAGKLbOZyKFJPnrTCY-OWbJBt7tnSpYTvXW39I4SA/edit#heading=h.mdc3u0ep3gmg)

+ On repo initialization, add include.path=../gitflow-branch-config
  to the repo's config file.
+ On self-update, initialize all repos to ensure that they have the
  proper gitflow branch configuration set.

Existing repos do not actually need to be updated more than once, nor is
self-update really an appropriate place to perform this action.  Ideally
there should be a migration step which can be independently triggered.
However, given the rarity with which self-update is run, and the low
penalty for performing the repo update (~ 1.5s/environment) this simple
solution was deemed acceptable.