### PR TITLE
Fixing broken link for impact-server war file

### DIFF
--- a/zendev/cmd/impact_devimg.py
+++ b/zendev/cmd/impact_devimg.py
@@ -22,7 +22,7 @@ def impact_devimg(args, env):
     #  if the version changes.  Better if the pom.xml set up a non-versioned symlink to the
     #  versioned file; then this could link to the non-versioned symlink.
     startup = """
-        SRC=/mnt/src/
+        SRC=/mnt/src
         DST=/opt/zenoss_impact
         VSN=%s
         ln -fs $SRC/impact-server/zenoss-dsa/target/impact-server.war $DST/webapps/impact-server.war


### PR DESCRIPTION
Building impact-image has broken link. Building impact-devimg creates a link with double slash like "impact-server.war -> /mnt/src//impact-server/zenoss-dsa/target/impact-server.war"