### PR TITLE
Check if temp files exist before sourcing them

### DIFF
--- a/zendev/bootstrap.sh
+++ b/zendev/bootstrap.sh
@@ -5,8 +5,10 @@ zendev () {
     export ZDCTLCHANNEL=$(mktemp -u /tmp/zd.${PID}.XXXXXXX)
     ${ZENDEV_SCRIPT} $@
     RC=$?
-    source "${ZDCTLCHANNEL}" > /dev/null 2>&1
-    rm -f ${ZDCTLCHANNEL}
+    if [ -f ${ZDCTLCHANNEL} ]; then
+        source "${ZDCTLCHANNEL}" > /dev/null 2>&1
+        rm -f ${ZDCTLCHANNEL}
+    fi
     unset ZDCTLCHANNEL
     return ${RC}
 }
@@ -16,6 +18,8 @@ eval "$(jig bootstrap --cd-command=cdz)"
 if [ ${BASH_VERSION:0:1} -ge 4 ]; then
     ZENDEV_ARGCOMPLETE=$(mktemp -u /tmp/zd.argcomplete.XXXXX)
     activate-global-python-argcomplete --dest=- > "${ZENDEV_ARGCOMPLETE}"
-    source "${ZENDEV_ARGCOMPLETE}"
-    rm -f "${ZENDEV_ARGCOMPLETE}"
+    if [ -f ${ZENDEV_ARGCOMPLETE} ]; then
+        source "${ZENDEV_ARGCOMPLETE}"
+        rm -f "${ZENDEV_ARGCOMPLETE}"
+    fi
 fi


### PR DESCRIPTION
If a temp files do not exist, the script will raise an error while sourcing it. This behavior can be unfavorable in some situations, e.g., a Jenkins build job.