### PR TITLE
zendev drop removes invalid entries in environments.json

### DIFF
--- a/zendev/cmd/environment.py
+++ b/zendev/cmd/environment.py
@@ -44,7 +44,11 @@ def drop(args, env):
     """
     Drop a zendev environment.
     """
-    get_config().remove(args.name, not args.purge)
+    config = get_config()
+    if args.name:
+        config.remove(args.name, not args.purge)
+    else:
+        config.cleanup()
 
 
 def env(args, env):
@@ -70,7 +74,9 @@ def add_commands(subparsers):
     use_parser.set_defaults(functor=use)
 
     drop_parser = subparsers.add_parser('drop', help='Delete an environment')
-    drop_parser.add_argument('name', metavar='ENVIRONMENT').completer = EnvironmentCompleter
+    drop_parser.add_argument(
+            'name', metavar='ENVIRONMENT', nargs='?', default=None
+            ).completer = EnvironmentCompleter
     drop_parser.add_argument('--purge', action="store_true")
     drop_parser.set_defaults(functor=drop)
 

--- a/zendev/config.py
+++ b/zendev/config.py
@@ -1,6 +1,7 @@
 import json
 import py
 import sys
+import os
 
 from .log import info, error
 
@@ -80,6 +81,18 @@ class ZendevConfig(object):
             return False
 
         return True
+
+
+    def cleanup(self):
+        trash = []
+        for key, value in self.environments.iteritems():
+            if not os.path.exists(value['path']):
+                trash.append(key)
+
+        for item in trash:
+            self.environments.pop(item)
+
+        self.save()
 
 
 def get_config():


### PR DESCRIPTION
If a zendev env foo is removed improperly, e.g., delete the directory instead of using zendev drop foo, the entry for foo still exists in environments.json but the path becomes invalid. Executing zendev drop with no other arguments removes all invalid entries from environments.json.