### PR TITLE
Update newdev-installer to install currently used docker-ce

### DIFF
--- a/binscripts/newdev-installer
+++ b/binscripts/newdev-installer
@@ -19,7 +19,7 @@ display_error() {
 : ${USER?"USER must be set"}
 
 DEVICE=$1
-DOCKER_VERSION=1.11.2-0
+DOCKER_VERSION=17.03.1~ce-0
 VGNAME=docker
 CREATE_THINPOOL=true
 THINPOOL=
@@ -120,9 +120,10 @@ if ${CONF_THINPOOL} ; then
 fi
 
 echo "Installing docker..."
-sudo apt-add-repository "deb https://apt.dockerproject.org/repo ubuntu-${UBUNTU_VERSION} main" || display_error "Failed to add docker repo"
+sudo apt-add-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" || display_error "Failed to add docker repo"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo apt-get update  > /dev/null 2>&1
-sudo apt-get install -y docker-engine=${DOCKER_VERSION}~${UBUNTU_VERSION} || display_error "failed to install docker"
+sudo apt-get install -y docker-ce=${DOCKER_VERSION}~ubuntu-${UBUNTU_VERSION} || display_error "failed to install docker"
 sudo apt-mark hold docker-engine || display_error "failed to apt-mark hold docker"
 sudo usermod -a -G docker ${USER} || display_error "failed to add ${USER} to docker group"
 

--- a/binscripts/newdev-installer
+++ b/binscripts/newdev-installer
@@ -124,7 +124,7 @@ sudo apt-add-repository "deb [arch=amd64] https://download.docker.com/linux/ubun
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo apt-get update  > /dev/null 2>&1
 sudo apt-get install -y docker-ce=${DOCKER_VERSION}~ubuntu-${UBUNTU_VERSION} || display_error "failed to install docker"
-sudo apt-mark hold docker-engine || display_error "failed to apt-mark hold docker"
+sudo apt-mark hold docker-ce || display_error "failed to apt-mark hold docker"
 sudo usermod -a -G docker ${USER} || display_error "failed to add ${USER} to docker group"
 
 echo "Configuring docker..."


### PR DESCRIPTION
Tested in AWS:

> Creating thinpool with device /dev/xvdc...
  Physical volume "/dev/xvdc" successfully created
  Volume group "docker" successfully created
  Logical volume "docker-pool" created.
Installing docker...
OK
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  aufs-tools cgroupfs-mount libltdl7
Suggested packages:
  mountall
The following NEW packages will be installed:
  aufs-tools cgroupfs-mount docker-ce libltdl7
0 upgraded, 4 newly installed, 0 to remove and 59 not upgraded.
Need to get 19.4 MB of archives.
After this operation, 89.4 MB of additional disk space will be used.
Get:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu xenial/universe amd64 aufs-tools amd64 1:3.2+20130722-1.1ubuntu1 [92.9 kB]
Get:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4,970 B]
Get:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]
Get:4 https://download.docker.com/linux/ubuntu xenial/stable amd64 docker-ce amd64 17.03.1~ce-0~ubuntu-xenial [19.3 MB]
Fetched 19.4 MB in 0s (20.6 MB/s)    
Selecting previously unselected package aufs-tools.
(Reading database ... 89653 files and directories currently installed.)
Preparing to unpack .../aufs-tools_1%3a3.2+20130722-1.1ubuntu1_amd64.deb ...
Unpacking aufs-tools (1:3.2+20130722-1.1ubuntu1) ...
Selecting previously unselected package cgroupfs-mount.
Preparing to unpack .../cgroupfs-mount_1.2_all.deb ...
Unpacking cgroupfs-mount (1.2) ...
Selecting previously unselected package libltdl7:amd64.
Preparing to unpack .../libltdl7_2.4.6-0.1_amd64.deb ...
Unpacking libltdl7:amd64 (2.4.6-0.1) ...
Selecting previously unselected package docker-ce.
Preparing to unpack .../docker-ce_17.03.1~ce-0~ubuntu-xenial_amd64.deb ...
Unpacking docker-ce (17.03.1~ce-0~ubuntu-xenial) ...
Processing triggers for libc-bin (2.23-0ubuntu9) ...
Processing triggers for man-db (2.7.5-1) ...
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for systemd (229-4ubuntu16) ...
Setting up aufs-tools (1:3.2+20130722-1.1ubuntu1) ...
Setting up cgroupfs-mount (1.2) ...
Setting up libltdl7:amd64 (2.4.6-0.1) ...
Setting up docker-ce (17.03.1~ce-0~ubuntu-xenial) ...
Processing triggers for libc-bin (2.23-0ubuntu9) ...
Processing triggers for systemd (229-4ubuntu16) ...
Processing triggers for ureadahead (0.100.0-19) ...
docker-ce set on hold.
Configuring docker...
Docker configured to use thinpool /dev/mapper/docker-docker--pool.
Adding zenny to sudo
May need to re-login to see user group changes.
Please make sure git ssh keys are set up for your user.
zenny@ip-10-111-23-101:~/zendev$ docker version
Client:
 Version:      17.03.1-ce
 API version:  1.27
 Go version:   go1.7.5
 Git commit:   c6d412e
 Built:        Mon Mar 27 17:14:09 2017
 OS/Arch:      linux/amd64