### PR TITLE
For devimg and test, always run 'make generate-zversion' in prodbin

### DIFF
--- a/zendev/cmd/devimg.py
+++ b/zendev/cmd/devimg.py
@@ -22,6 +22,8 @@ def devimg(args, env):
     defined on the zendev command line.
     """
     environ = env()
+    environ.generateZVersions()
+
     cmdArgs = ['make']
     if args.clean:
         cmdArgs.append('clean')
@@ -73,7 +75,6 @@ def _createZPFile(environ, zenpackList):
         with zenpackManifestFile.open("w") as jsonFile:
             json.dump(zenpacks, jsonFile, sort_keys=True, indent=4, separators=(',', ': '))
         return zenpackManifestFile.strpath
-
 
 def add_commands(subparsers):
     devimg_parser = subparsers.add_parser('devimg',

--- a/zendev/cmd/test.py
+++ b/zendev/cmd/test.py
@@ -7,11 +7,14 @@ from ..devimage import DevImage
 
 
 def test(args, env):
+
     cmd = ["docker", "run", "-i", "-t", "--rm"]
     if args.no_tty:
         cmd.remove("-t")
 
-    devImage = DevImage(env())
+    environ = env()
+    environ.generateZVersions()
+    devImage = DevImage(environ)
     mounts = devImage.get_mounts()
     for mount in mounts.iteritems():
         cmd.extend(["-v", "%s:%s" % mount])


### PR DESCRIPTION
These changes are intended to work with https://github.com/zenoss/zenoss-prodbin/pull/2605 which implements programmatic management of schema versions for `Migrate.Version()` - see Products/ZenModel/migrate/README.md in that PR for more info.

Note that  because the make target `generate-zversion` exists in older versions of prodbin, these changes should be harmless when run against older versions of Zenoss.