### PR TITLE
Work with gcloud

### DIFF
--- a/zendev/cmd/devimg.py
+++ b/zendev/cmd/devimg.py
@@ -41,7 +41,7 @@ def devimg(args, env):
         # of product-assembly which are NOT actually product directories
         zenpackManifestFile = targetDir.join("zenpacks.json")
         if not zenpackManifestFile.check():
-            error("Target product '%s' does not appear to be a valid product. Could not find %s" % (args.target_product, zenpackManifestFile.strpath))
+            error("Target product '%s' does not appear to be a valid product. Could not find %s" % (args.product, zenpackManifestFile.strpath))
             sys.exit(1)
         cmdArgs.append("TARGET_PRODUCT=%s" % args.product)
 

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -74,7 +74,7 @@ class ZenDevEnvironment(object):
         previousMod = os.environ.get('ZD_PATH_MOD', "")
         if len(previousMod) > 0:
             origpath = origpath.replace(previousMod, "")
-        newMod = "%s/bin:%s/bin:" % (self.gopath, self._zenhome)
+        newMod = "%s/bin:" % (self.gopath)
         return {
             "ZENHOME": self._zenhome.strpath,
             "SRCROOT": self._srcroot.strpath,


### PR DESCRIPTION
Changes to work with the gcloud CLI and to work with the new Zenoss.cse image
* Do not include ZENHOME/bin in the PATH because it interferes with other python CLIs, like `gcloud`
* Optionally, map in the proper image name for `zing-connector` when compiling service templates (e.g. `zendev serviced -d ...`)