### PR TITLE
Copy the zenpack.json file into the environment

### DIFF
--- a/zendev/cmd/devimg.py
+++ b/zendev/cmd/devimg.py
@@ -50,7 +50,9 @@ def devimg(args, env):
         if not zenpackManifestFile.check():
             error("File '%s' does not exist" % zenpackManifestFile.strpath)
             sys.exit(1)
-        cmdArgs.append("ZENPACK_FILE=%s" % zenpackManifestFile.strpath)
+        tmpZenpackManifestFile = environ.root.join("tmp/zenpacks.json")
+        zenpackManifestFile.copy(tmpZenpackManifestFile)
+        cmdArgs.append("ZENPACK_FILE=%s" % tmpZenpackManifestFile.strpath)
 
     elif args.zenpacks:
         zenpacks = args.zenpacks.split(",")


### PR DESCRIPTION
Previously, the command "zendev devimg -f zenpack.json" woul not work
properly if the zenpack.json file were not in the zendev environment.
This change allows for that file to exist anywhere by copying the file
into the environment.