### PR TITLE
Initialize env to specified tag.

### DIFF
--- a/zendev/cmd/environment.py
+++ b/zendev/cmd/environment.py
@@ -26,10 +26,9 @@ def init(args, _):
         except NotInitialized:
             init_config_dir()
             env = ZenDevEnvironment(name=name, path=path)
-        env.initialize(args.shallow)
+        tag = args.tag or "develop"
+        env.initialize(args.shallow, tag=tag)
         env.use()
-    if args.tag:
-        env.restore(args.tag, shallow=args.shallow)
     return env
 
 

--- a/zendev/environment.py
+++ b/zendev/environment.py
@@ -161,11 +161,11 @@ class ZenDevEnvironment(object):
         if not self._srcroot.join(".jig").check():
             subprocess.check_call(['jig', 'init'])
 
-    def initialize(self, shallow=False):
+    def initialize(self, shallow=False, tag="develop"):
         # Clone product-assembly directory
         self._initializeJig()
-        # Start with the latest code on develop
-        self.restore('develop', shallow=shallow)
+        # Initialize the env with the specified tag
+        self.restore(tag, shallow=shallow)
 
     def generateRepoJSON(self):
         repos_sh = self._productAssembly.join('repos.sh')


### PR DESCRIPTION
When --shallow is given, specifying a tag other than 'develop' fails to checkout the repos as given in product-assembly.  This change will initialize an environment to the specified tag without checking out develop first.

Output of `zendev init --shallow --tag support/6.x testing`:
Before fix: [gist showing issue](https://gist.github.com/jpeacock-zenoss/21f8df05a5c2ccd6134c987388290eb3)
After fix: [gist showing fix](https://gist.github.com/jpeacock-zenoss/5bec6b008963629c32023c01ed0a3b44)

It hasn't been noticed before because develop and support/* branches of product-assembly have been relatively in-sync.